### PR TITLE
Fix/allow empty post body

### DIFF
--- a/lib/oidc.js
+++ b/lib/oidc.js
@@ -8,6 +8,19 @@ const {
 const { encrypt, decrypt } = require('./utils/crypto')
 
 // Helper functions
+// ----------------------------------
+
+// openid-client v4 and v5 does not handle authentication on POST-requests where the request body is undefined.
+// This is a potential case after upgrading an app to express@5, where the built in body parsers no longer handles requests with unspecified ContentType
+// This helper should not be needed if upgrading to openid-client@6
+const ensurePostBody = req => {
+  if (req.method === 'POST') {
+    if (!req.body) {
+      req.body = ''
+    }
+  }
+}
+
 function isCallbackConfigured(type, callback, appCallback) {
   if (callback && appCallback) {
     return true
@@ -404,6 +417,7 @@ class OIDC {
       const newState = generateState()
       req.session[redirectPropertyName(newState)] = req.url
 
+      ensurePostBody(req)
       return passport.authenticate('oidc', { state: newState })(req, res, next)
     })(req, res, next)
   }
@@ -465,6 +479,8 @@ class OIDC {
             return next(err)
           }
         })
+
+        ensurePostBody(req)
         return passport.authenticate(
           createSilentLoginStrategy(client, callbackSilentLoginUrl, newState, tokenSecret, extendUser),
           {

--- a/lib/oidc.js
+++ b/lib/oidc.js
@@ -16,7 +16,7 @@ const { encrypt, decrypt } = require('./utils/crypto')
 const ensurePostBody = req => {
   if (req.method === 'POST') {
     if (!req.body) {
-      req.body = ''
+      req.body = {}
     }
   }
 }

--- a/lib/oidc.test.js
+++ b/lib/oidc.test.js
@@ -158,7 +158,7 @@ describe('fixing empty POST body', () => {
     req.body = undefined
     const result = await oidc.login(req)
 
-    expect(req.body).toEqual('')
+    expect(req.body).toEqual({})
   })
   test('Add a empty body if body is missing on POST request to /silentLogin', async () => {
     const oidc = new OpenIDConnect(server, passport, config)
@@ -169,7 +169,7 @@ describe('fixing empty POST body', () => {
 
     const result = await oidc.silentLogin(req, res, next)
 
-    expect(req.body).toEqual('')
+    expect(req.body).toEqual({})
   })
   test("Don't add body to GET request", async () => {
     const oidc = new OpenIDConnect(server, passport, config)

--- a/lib/oidc.test.js
+++ b/lib/oidc.test.js
@@ -5,6 +5,12 @@
  *
  */
 
+jest.mock('openid-client', () => ({
+  Issuer: { discover: jest.fn().mockResolvedValue({ Client: jest.fn() }) },
+  Strategy: jest.fn(),
+  generators: { state: jest.fn() },
+}))
+
 const {
   OIDC: OpenIDConnect,
   extractDisplayName,
@@ -113,5 +119,74 @@ describe(`Helper functions tests`, () => {
     req.cookies[socialToolbarCookieName] = {}
 
     expect(foundToolbarCookie(req)).toBe(true)
+  })
+})
+
+describe('fixing empty POST body', () => {
+  let req = {}
+  const res = {}
+  const next = jest.fn()
+
+  const server = { get: () => {} }
+  const passport = {
+    use: jest.fn(),
+    authenticate: jest.fn(() => jest.fn()),
+  }
+  const config = {
+    configurationUrl: 'https://kth.se/openid-configuration',
+
+    clientId: 'mockId',
+    clientSecret: 'mockSecret',
+    tokenSecret: 'mockTokenSecret',
+    defaultRedirect: 'mockRedirect',
+
+    callbackLoginUrl: 'https://kth.se/my-app/auth/login/callback',
+    callbackSilentLoginUrl: 'https://kth.se/my-app/auth/silent/callback',
+    callbackLogoutUrl: 'https://kth.se/my-app/auth/logout/callback',
+
+    callbackLoginRoute: '/auth/login/callback',
+    callbackLogoutRoute: '/auth/logout/callback',
+    callbackSilentLoginRoute: '/auth/silent/callback',
+  }
+  beforeEach(() => {
+    req = { session: { save: jest.fn() } }
+  })
+  test('Add a empty body if body is missing on POST request to /login', async () => {
+    const oidc = new OpenIDConnect(server, passport, config)
+
+    req.method = 'POST'
+    req.body = undefined
+    const result = await oidc.login(req)
+
+    expect(req.body).toEqual('')
+  })
+  test('Add a empty body if body is missing on POST request to /silentLogin', async () => {
+    const oidc = new OpenIDConnect(server, passport, config)
+
+    req.method = 'POST'
+    req.body = undefined
+    req.cookies = { KTH_SSO_START: 't' }
+
+    const result = await oidc.silentLogin(req, res, next)
+
+    expect(req.body).toEqual('')
+  })
+  test("Don't add body to GET request", async () => {
+    const oidc = new OpenIDConnect(server, passport, config)
+
+    req.method = 'GET'
+    req.body = undefined
+    const result = await oidc.login(req)
+
+    expect(req.body).toEqual(undefined)
+  })
+  test("Don't affect existing body", async () => {
+    const oidc = new OpenIDConnect(server, passport, config)
+
+    req.method = 'POST'
+    req.body = { status: 'body exists' }
+    const result = await oidc.login(req)
+
+    expect(req.body).toEqual({ status: 'body exists' })
   })
 })

--- a/package-lock.json
+++ b/package-lock.json
@@ -1745,9 +1745,9 @@
       }
     },
     "node_modules/@types/http-cache-semantics": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.1.tgz",
-      "integrity": "sha512-SZs7ekbP8CN0txVG2xVRH6EgKmEm31BOxA07vkFaETzZz1xh+cbt8BcI0slpymvwhx5dlFnQG2rTlPVQn+iRPQ=="
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.4.tgz",
+      "integrity": "sha512-1m0bIFVc7eJWyve9S0RnuRgcQqF/Xd5QsUZAZeQFr1Q3/p9JWoQQEqmVy+DPTNpGXwhgIetAoYF8JSc33q29QA=="
     },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.6",
@@ -1821,9 +1821,9 @@
       "integrity": "sha512-rt40Nk13II9JwQBdeYqmbn2Q6IVTA5uPhvSO+JVqdXw/6/4glI6oR9ezty/A9Hg5u7JH4OmYmuQ+XvjKm0Datg=="
     },
     "node_modules/@types/responselike": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.0.tgz",
-      "integrity": "sha512-85Y2BjiufFzaMIlvJDvTTB8Fxl2xfLo4HgmHzVBz08w4wDePCTjYw66PdrolO0kzli3yam/YCgRufyo1DdQVTA==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.3.tgz",
+      "integrity": "sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw==",
       "dependencies": {
         "@types/node": "*"
       }
@@ -3542,9 +3542,9 @@
       }
     },
     "node_modules/end-of-stream": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
-      "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
       "dependencies": {
         "once": "^1.4.0"
       }
@@ -5253,9 +5253,9 @@
       "dev": true
     },
     "node_modules/http-cache-semantics": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz",
-      "integrity": "sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ=="
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
+      "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ=="
     },
     "node_modules/http-errors": {
       "version": "2.0.0",
@@ -7722,9 +7722,9 @@
       }
     },
     "node_modules/keyv": {
-      "version": "4.5.3",
-      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.3.tgz",
-      "integrity": "sha512-QCiSav9WaX1PgETJ+SpNnx2PRRapJ/oRSXM4VO5OGYGSjrxbKPVFVhB3l2OCbLCk329N8qyAtsJjSjvVBWzEug==",
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
       "dependencies": {
         "json-buffer": "3.0.1"
       }
@@ -8414,9 +8414,9 @@
       }
     },
     "node_modules/oidc-token-hash": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/oidc-token-hash/-/oidc-token-hash-5.0.3.tgz",
-      "integrity": "sha512-IF4PcGgzAr6XXSff26Sk/+P4KZFJVuHAJZj3wgO3vX2bMdNVp/QXTP3P7CEm9V1IdG8lDLY3HhiqpsE/nOwpPw==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/oidc-token-hash/-/oidc-token-hash-5.1.1.tgz",
+      "integrity": "sha512-D7EmwxJV6DsEB6vOFLrBM2OzsVgQzgPWyHlV2OOAVj772n+WTXpudC9e9u5BVKQnYwaD30Ivhi9b+4UeBcGu9g==",
       "engines": {
         "node": "^10.13.0 || >=12.0.0"
       }
@@ -8957,9 +8957,9 @@
       }
     },
     "node_modules/pump": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
-      "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.3.tgz",
+      "integrity": "sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==",
       "dependencies": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"


### PR DESCRIPTION
AB#5630


Should prevent the following after upgrading apps to express@5

```
Unhandled error incoming message body missing, include a body parser prior to this method call
TypeError: incoming message body missing, include a body parser prior to this method call
    at Client.callbackParams (/Users/nsan/code/kth/packages/kth-node-passport-oidc/node_modules/openid-client/lib/client.js:355:19)
    at /Users/nsan/code/kth/packages/kth-node-passport-oidc/node_modules/openid-client/lib/passport_strategy.js:86:30
    at OpenIDConnectStrategy.authenticate (/Users/nsan/code/kth/packages/kth-node-passport-oidc/node_modules/openid-client/lib/passport_strategy.js:176:5)
    at attempt (/Users/nsan/code/kth/node-apps/profiles-web/node_modules/passport/lib/middleware/authenticate.js:378:16)
    at authenticate (/Users/nsan/code/kth/node-apps/profiles-web/node_modules/passport/lib/middleware/authenticate.js:379:7)
    at /Users/nsan/code/kth/packages/kth-node-passport-oidc/lib/oidc.js:421:64
    at login (/Users/nsan/code/kth/packages/kth-node-passport-oidc/lib/oidc.js:422:7)
    at Layer.handleRequest (/Users/nsan/code/kth/node-apps/profiles-web/node_modules/router/lib/layer.js:152:17)
    at next (/Users/nsan/code/kth/node-apps/profiles-web/node_modules/router/lib/route.js:157:13)
    at loggerMW (/Users/nsan/code/kth/node-apps/profiles-web/server/server.js:557:3)
    at Layer.handleRequest (/Users/nsan/code/kth/node-apps/profiles-web/node_modules/router/lib/layer.js:152:17)
    at next (/Users/nsan/code/kth/node-apps/profiles-web/node_modules/router/lib/route.js:157:13)
    at Route.dispatch (/Users/nsan/code/kth/node-apps/profiles-web/node_modules/router/lib/route.js:117:3)
    at handle (/Users/nsan/code/kth/node-apps/profiles-web/node_modules/router/index.js:435:11)
    at Layer.handleRequest (/Users/nsan/code/kth/node-apps/profiles-web/node_modules/router/lib/layer.js:152:17)
    at /Users/nsan/code/kth/node-apps/profiles-web/node_modules/router/index.js:295:15
```